### PR TITLE
Fix crash when macro appears at end of string. Whitespace.

### DIFF
--- a/richtext.lua
+++ b/richtext.lua
@@ -94,13 +94,13 @@ end
 
 function rich:parse(t)
 	local text = t[1]
-	if string.len(text) > 0 then 
+	if string.len(text) > 0 then
 		-- look for {tags} or [tags]
 		for textfragment, foundtag in text:gmatch'([^{]*){(.-)}' do
 			parsefragment(self.parsedtext, textfragment)
 			table.insert(self.parsedtext, self.resources[foundtag] or foundtag)
 		end
-		parsefragment(self.parsedtext, text:match('[^}]+$'))
+		parsefragment(self.parsedtext, text:match('[^}]+$') or '')
 	end
 end
 
@@ -168,7 +168,7 @@ local function wrapText(parsedtext, fragment, lines, maxheight, x, width, i, fnt
 		x = 0
 		table.insert(lines, {})
 	end
-	
+
 	return maxheight, 0
 end
 


### PR DESCRIPTION
Fix for issue: https://github.com/gvx/richtext/issues/9